### PR TITLE
Add FlatHub verification token

### DIFF
--- a/.well-known/org.flathub.VerifiedApps.txt
+++ b/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,2 @@
+# Exult Flatpak verification token for https://flathub.org/apps/info.exult.exult
+37cdc631-910f-4b63-94d6-60cc8f73c308


### PR DESCRIPTION
This file can be checked by Flathub to mark an app distribution as "verified" (ie. made with the endorsement and control of the actual app's maintainers). Depending on the settings for a user's Flatpak installation, unverified apps may be hidden from search results by default and Flathub have suggested this may be coming to the web listings as well.