### PR TITLE
Dynamic Snapshot updating on Download Page

### DIFF
--- a/default.css
+++ b/default.css
@@ -72,16 +72,18 @@ table.link_table td {
 	vertical-align: top;
 }
 
-table.download_link {
+table#download_links {
 	border-spacing: 3px;
 	border-width: 0;
 }
 
-table.download_link th,
-table.download_link td {
+table#download_links th,
+table#download_links td {
 	padding: 1px;
 }
-
+table#download_links td.datetime-column {
+	padding-right: 1em;
+}
 table.key_table {
 	border-spacing: 2px;
 	border-width: 0;
@@ -135,12 +137,18 @@ td.centered>* {
 }
 
 th.right-aligned,
-td.right-aligned {
+td.right-aligned,
+th.size-column,
+td.size-column
+{	
 	text-align: right;
 }
 
 th.right-aligned>*,
-td.right-aligned>* {
+td.right-aligned>*,
+th.size-column>*,
+td.size-column>*
+{
 	margin-left: auto;
 	margin-right: 0;
 }

--- a/download.html
+++ b/download.html
@@ -104,7 +104,7 @@
 					</p>
 					<p>
 					</p>
-					<table class="download_link">
+					<table id="download_links">
 						<tr>
 							<td colspan="2"><b>Exult v1.12.0 - official release - 2025-05-11</b></td>
 							<td class="blank-column"></td>
@@ -112,27 +112,27 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.exe">Exult for Windows installer (7/8/10/11)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">22 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.exe">Exult for Windows installer (7/8/10/11)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">22 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0-1.dmg">Exult for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">16 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0-1.dmg">Exult for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">16 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.apk">Exult for Android</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">59 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.apk">Exult for Android</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">59 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.tar.gz">Exult Sourcecode (.tar.gz)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">19 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-1.12.0.tar.gz">Exult Sourcecode (.tar.gz)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">19 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -147,27 +147,27 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-studio-1.12.0.exe">Exult Studio for Windows (7/8/10/11)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">69 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-studio-1.12.0.exe">Exult Studio for Windows (7/8/10/11)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">69 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-studio-1.12.0.dmg">Exult Studio for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">66 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-studio-1.12.0.dmg">Exult Studio for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">66 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-tools-1.12.0.exe">Exult Tools for Windows (7/8/10/11)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">22 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-tools-1.12.0.exe">Exult Tools for Windows (7/8/10/11)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">22 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult-tools-macOS-1.12.0.zip">Exult Tools for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">4 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult-tools-macOS-1.12.0.zip">Exult Tools for macOS 10.12 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">4 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -182,27 +182,27 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://github.com/exult/exult/commits/master">Changelog</a></td>
-							<td class="blank-column"><br /></td>
+							<td class="link-column"><a href="https://github.com/exult/exult/commits/master">Changelog</a></td>
+							<td class="datetime-column"><br /></td>
 							<td></td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Exult.exe">Exult for Windows 7/8/10/11</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">22 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Exult.exe">Exult for Windows 7/8/10/11</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">22 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Exult-snapshot.dmg">Exult for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">19 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Exult-snapshot.dmg">Exult for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">19 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/exult-snapshot-signed.apk">Exult for Android</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">60 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/exult-snapshot-signed.apk">Exult for Android</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">60 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -217,27 +217,27 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/ExultStudio.exe">Exult Studio for Windows</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">64 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/ExultStudio.exe">Exult Studio for Windows</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">64 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/ExultStudio-snapshot.dmg">Exult Studio for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">63 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/ExultStudio-snapshot.dmg">Exult Studio for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">63 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/ExultTools.exe">Exult Tools for Windows</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">6 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/ExultTools.exe">Exult Tools for Windows</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">6 MB</td>
 						</tr>
 						<tr>
-							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/exult_tools_macOS.zip">Exult Tools for for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">5 MB</td>
+							<td class="size-column"></td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/exult_tools_macOS.zip">Exult Tools for for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">5 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -252,33 +252,33 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Gimp30Plugin.exe">The GIMP 3.x Plug-in for Windows</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">2 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Gimp30Plugin.exe">The GIMP 3.x Plug-in for Windows</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">2 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Gimp30Plugin.pkg">The GIMP 3.x Plug-in for macOS 11.x - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Gimp30Plugin.pkg">The GIMP 3.x Plug-in for macOS 11.x - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Gimp20Plugin.exe">The GIMP 2.x Plug-in for Windows</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">2 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Gimp20Plugin.exe">The GIMP 2.x Plug-in for Windows</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">2 MB</td>
 						</tr>
-						<tr>
+						<tr id="win64_aseprite-extension">
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/exult_shp_win64.aseprite-extension">Aseprite Plug-in for Windows 64bit</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/exult_shp_win64.aseprite-extension">Aseprite Plug-in for Windows 64bit</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
-						<tr>
+						<tr id="macos_aseprite-extension">
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/exult_shp_macos.aseprite-extension">Aseprite Plug-in for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/exult_shp_macos.aseprite-extension">Aseprite Plug-in for macOS 10.15 - 15.x (64-bit intel/arm64)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -293,21 +293,21 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/Exult_Audio_Installer.exe">Installer for Windows</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">45 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/Exult_Audio_Installer.exe">Installer for Windows</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">45 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/Exult_Audio_Installer.dmg">Installer for macOS</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">50 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/Exult_Audio_Installer.dmg">Installer for macOS</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">50 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/exult_audio.zip">Zipped all-in-one audio pack for manual installation</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">48 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/exult_audio.zip">Zipped all-in-one audio pack for manual installation</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">48 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -322,39 +322,39 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/jmsfx.zip">Sound pack for Black Gate</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">4 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/jmsfx.zip">Sound pack for Black Gate</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">4 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/sqsfxbg.zip">Sound pack for Black Gate (Roland MT-32)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">6 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/sqsfxbg.zip">Sound pack for Black Gate (Roland MT-32)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">6 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/jmsfxsi.zip">Sound pack for Serpent Isle</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">6 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/jmsfxsi.zip">Sound pack for Serpent Isle</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">6 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/sqsfxsi.zip">Sound pack for Serpent Isle (Roland MT-32)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">8 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/sqsfxsi.zip">Sound pack for Serpent Isle (Roland MT-32)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">8 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/U7MusicOGG_1of2.zip">Ogg encoded Music files for Exult Part 1</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">12 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/U7MusicOGG_1of2.zip">Ogg encoded Music files for Exult Part 1</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">12 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://prdownloads.sourceforge.net/exult/U7MusicOGG_2of2.zip">Ogg encoded Music files for Exult Part 2</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">11 MB</td>
+							<td class="link-column"><a href="http://prdownloads.sourceforge.net/exult/U7MusicOGG_2of2.zip">Ogg encoded Music files for Exult Part 2</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">11 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -369,21 +369,21 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Keyring.zip">Marzo's Black Gate Keyring (requires FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Keyring.zip">Marzo's Black Gate Keyring (requires FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Sifixes.zip">Marzo's Serpent Isle Fixes (requires SS)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Sifixes.zip">Marzo's Serpent Isle Fixes (requires SS)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/SFisland.zip">SourceForge Island (requires FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/SFisland.zip">SourceForge Island (requires FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -398,37 +398,37 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Ultima6.zip">Ultima VI Remake 1.2 (requires Exult 1.10 and FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">55 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Ultima6.zip">Ultima VI Remake 1.2 (requires Exult 1.10 and FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">55 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/Glimmerscape_SI_mod_by_Donfrow.zip">Glimmerscape by Donfrow (requires SS)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">13 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/Glimmerscape_SI_mod_by_Donfrow.zip">Glimmerscape by Donfrow (requires SS)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">13 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/u6patch.zip">Ultima VI conversion by Mike Fictiti0us (requires FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">5 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/u6patch.zip">Ultima VI conversion by Mike Fictiti0us (requires FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">5 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/m-johnston-mod.zip">Matthew Johnston's unnamed mod (requires FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">3 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/m-johnston-mod.zip">Matthew Johnston's unnamed mod (requires FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">3 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/quests_and_interactions-0.6b.zip">Alun Bestor's Quests and Interactions mod version 0.6beta (requires FoV)</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/quests_and_interactions-0.6b.zip">Alun Bestor's Quests and Interactions mod version 0.6beta (requires FoV)</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://sourceforge.net/projects/u7feudallands/">The Feudal Lands by Wizardry Dragon (requires FoV)</a></td>
+							<td class="link-column"><a href="https://sourceforge.net/projects/u7feudallands/">The Feudal Lands by Wizardry Dragon (requires FoV)</a></td>
 							<td class="blank-column"><br /></td>
 							<td></td>
 						</tr>
@@ -445,39 +445,39 @@
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/fonts_replacement.zip">Alternate fonts based on Kanto, enhanced by Sir John and Dominus for all official releases</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/fonts_replacement.zip">Alternate fonts based on Kanto, enhanced by Sir John and Dominus for all official releases</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="http://exult.info/seventowers/downloads.php?section=0&page=3">Marzo's Avatar Pack</a></td>
+							<td class="link-column"><a href="http://exult.info/seventowers/downloads.php?section=0&page=3">Marzo's Avatar Pack</a></td>
 							<td class="blank-column"><br /></td>
 							<td></td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/size_patch.zip">Malignant Manor's size patch increases the size of some shapes - ideal for smaller screens</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/size_patch.zip">Malignant Manor's size patch increases the size of some shapes - ideal for smaller screens</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/si_bg_merge_ver_6.9.zip">Malignant Manor's SI-BG merge</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">3 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/si_bg_merge_ver_6.9.zip">Malignant Manor's SI-BG merge</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">3 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/u7gm.zip">Newton Dragon's BG/FoV GM patch prepackaged as a mod</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/u7gm.zip">Newton Dragon's BG/FoV GM patch prepackaged as a mod</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"></td>
-							<td><a href="https://exult.sourceforge.io/snapshots/sigm.zip">Newton Dragon's SI/SS GM patch prepackaged as a mod</a></td>
-							<td class="blank-column"><br /></td>
-							<td class="right-aligned">1 MB</td>
+							<td class="link-column"><a href="https://exult.sourceforge.io/snapshots/sigm.zip">Newton Dragon's SI/SS GM patch prepackaged as a mod</a></td>
+							<td class="datetime-column"><br /></td>
+							<td class="size-column">1 MB</td>
 						</tr>
 						<tr>
 							<td class="blank-column"><br /></td>
@@ -521,6 +521,6 @@
 			</tr>
 		</table>
 	</div>
+	<script src="download.js"></script>
 </body>
-
 </html>

--- a/download.js
+++ b/download.js
@@ -27,7 +27,7 @@ var Releases = /** @class */ (function () {
 }());
 // Update a download link row
 // Only updates the row if it has the 
-// datetime, size and  link column
+// datetime, size and link columns
 // The link column must contain a single A tag with a url that starts with https://exult.sourceforge.io/snapshots/
 // It matches the download filename with an Asset in the GitHub Release. If there is a match it fills in the DateTime cell
 // Changes the download url to the asset's download url on github and Updates the Size cell 
@@ -46,17 +46,17 @@ function TryUpdateSnapshotRow(release, row) {
         }
         else if (!link_elem && child.classList.contains("link-column")) {
             link_elem = child.firstElementChild;
-            // If the first child isn't a anchor tag or not link to a snapshot file
+            // If the first child isn't an anchor tag or not link to a snapshot file
             // Don't do anything as the row is not in the correct format
             if (link_elem.tagName !== 'A' || link_elem.href.substring(0, 39) !== 'https://exult.sourceforge.io/snapshots/')
                 return;
         }
     }
-    // If dudn't get all 3 cells do nothing
+    // If didn't get all 3 cells do nothing
     if (!datetime_cell || !size_cell || !link_elem)
         return;
     var asset = FindAsset(release, link_elem.href.substring(39));
-    // No asset in the Release matching the download's filename
+    // If no asset in the Release matching the download's filename do nothing
     if (!asset) {
         return;
     }
@@ -70,7 +70,7 @@ var request = new XMLHttpRequest();
 // Ask for 4 releases in the API call to github This should be enough to ensure we get the latest snapshot
 // Usually the snapshot wull be the first Release but if there was An Official Release after the latest snapshot, 
 // the snapshot will be second
-// ASk for 4 releases just to be safe 
+// Ask for 4 releases just to be safe 
 request.open('GET', 'https://api.github.com/repos/exult/exult/releases?per_page=4', true);
 request.setRequestHeader('X-GitHub-Api-Version', '2022-11-28');
 request.setRequestHeader('Accept', 'application/vnd.github+json');

--- a/download.js
+++ b/download.js
@@ -1,0 +1,89 @@
+function FindAsset(release, name, Predicate) {
+    var result = null;
+    (release.assets).some(function (asset) {
+        if (!result && asset.name === name && (!Predicate || Predicate(asset))) {
+            result = asset;
+            return true;
+        }
+    });
+    return result;
+}
+var Releases = /** @class */ (function () {
+    function Releases(json) {
+        this.data = JSON.parse(json);
+    }
+    ;
+    Releases.prototype.FindRelease = function (draft, prerelease, Predicate) {
+        var result = null;
+        (this.data).some(function (release) {
+            if (!result && release.draft === draft && release.prerelease === prerelease && (!Predicate || Predicate(release))) {
+                result = release;
+                return true;
+            }
+        });
+        return result;
+    };
+    return Releases;
+}());
+// Update a download link row
+// Only updates the row if it has the 
+// datetime, size and  link column
+// The link column must contain a single A tag with a url that starts with https://exult.sourceforge.io/snapshots/
+// It matches the download filename with an Asset in the GitHub Release. If there is a match it fills in the DateTime cell
+// Changes the download url to the asset's download url on github and Updates the Size cell 
+function TryUpdateSnapshotRow(release, row) {
+    var datetime_cell;
+    var size_cell;
+    var link_elem;
+    // Iterate over cells in row. Using standard for loop for compatibility with older browsers that don't allow iterating HTMLColleection Objects
+    for (var index = 0; index < row.cells.length; index++) {
+        var child = row.cells.item(index);
+        if (!datetime_cell && child.classList.contains("datetime-column")) {
+            datetime_cell = child;
+        }
+        else if (!size_cell && child.classList.contains("size-column")) {
+            size_cell = child;
+        }
+        else if (!link_elem && child.classList.contains("link-column")) {
+            link_elem = child.firstElementChild;
+            // If the first child isn't a anchor tag or not link to a snapshot file
+            // Don't do anything as the row is not in the correct format
+            if (link_elem.tagName !== 'A' || link_elem.href.substring(0, 39) !== 'https://exult.sourceforge.io/snapshots/')
+                return;
+        }
+    }
+    // If dudn't get all 3 cells do nothing
+    if (!datetime_cell || !size_cell || !link_elem)
+        return;
+    var asset = FindAsset(release, link_elem.href.substring(39));
+    // No asset in the Release matching the download's filename
+    if (!asset) {
+        return;
+    }
+    var datetime = new Date(asset.updated_at);
+    datetime_cell.innerHTML = datetime.getFullYear() + '-' + (datetime.getMonth() + 1) + '-' + datetime.getDate() + '&nbsp;' + datetime.getHours() + ':' + datetime.getMinutes();
+    link_elem.href = asset.browser_download_url;
+    size_cell.innerHTML = Math.ceil(asset.size / (1024 * 1024)) + "&nbsp;MB";
+}
+var releases;
+var request = new XMLHttpRequest();
+// Ask for 4 releases in the API call to github This should be enough to ensure we get the latest snapshot
+// Usually the snapshot wull be the first Release but if there was An Official Release after the latest snapshot, 
+// the snapshot will be second
+// ASk for 4 releases just to be safe 
+request.open('GET', 'https://api.github.com/repos/exult/exult/releases?per_page=4', true);
+request.setRequestHeader('X-GitHub-Api-Version', '2022-11-28');
+request.setRequestHeader('Accept', 'application/vnd.github+json');
+request.onload = function () {
+    releases = new Releases(request.responseText);
+    // Get the latest non draft prerelease that has a name starting with Snapshot
+    var Snapshot = releases.FindRelease(false, true, function (release) { return release.name.substring(0, 8) === "Snapshot"; });
+    if (Snapshot) {
+        var table = document.getElementById("download_links");
+        // Iterate over table rows. Using standard for loop for compatibility with older browsers that don't allow iterating HTMLColleection Objects
+        for (var index = 0; index < table.rows.length; index++) {
+            TryUpdateSnapshotRow(Snapshot, table.rows.item(index));
+        }
+    }
+};
+request.send();


### PR DESCRIPTION
Pull Request to add Javascript to the download page to  Add back to update date and time to snapshot files.

This set of changes uses javascript to call the GitHub Releases API to get the latest snapshot Release and it then updates the Table rows  of any matching Snapshot file and if a match ismade it adds the date and time as well as updating the link url to the Release Asset's download URL and updates the download Size of the file on git hub.

The script will update any download in https://exult.sourceforge.io/snapshots/ if the filename matches the names of the asset in the Github Release. This obviously means that if the file is not generated by our snapshot workflow it wont get dynamically updated.

Made some changes to the download.hml file to make it easier for the script to work and updated the css to reflect the download.html changes. Mostly table cells in download.html  now have classes to relflect what the cell is.

Date and Time shown by these changes is in local time. This seemed to me slightly more user friendly in particular for users like myself who are fairly far away from UTC. Csn change to UTC if desired


Screenshot of the page after these changes
<img width="1920" height="2450" alt="Screenshot 2025-08-20 at 23-41-18 Exult Download" src="https://github.com/user-attachments/assets/1e52f67c-32b9-4f97-9894-4cdd77c7ac48" />

A note to @DominusExult  The message at the bottom of the page "Problems with Exult or this webpage" has a link that points to the old forum. You may want to update it to something different. I didn't change it here as it is on every page.